### PR TITLE
TEST-002: workflow bootstrap test

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -31,6 +31,9 @@ jobs:
     name: Re-tag Current Dev Image from latest
     uses: ./.github/workflows/re_tag_current_image.yaml
     needs: test_image_deployment
+    permissions:
+      id-token: write
+      contents: read
     with:
       AWS_ECR_REPOSITORY: ${{ github.event.pull_request.base.ref == 'production' && vars.AWS_PROD_ECR_REPOSITORY || vars.AWS_DEV_ECR_REPOSITORY }}
       AWS_REGION: ${{ github.event.pull_request.base.ref == 'production' && vars.AWS_PROD_REGION || vars.AWS_DEV_REGION }}
@@ -41,6 +44,9 @@ jobs:
     name: Push to Dev ecr registry
     needs: re_tag_current_latest
     uses: ./.github/workflows/push_image_to_ecr.yaml
+    permissions:
+      id-token: write
+      contents: read
     with:
       IMAGE_TAG_SUFFIX: ${{ vars.IMAGE_TAG_SUFFIX }}
       ENVIRONMENT: ${{ github.event.pull_request.base.ref }}


### PR DESCRIPTION
fixed failed test due to low permissions

`Invalid workflow file: .github/workflows/pipeline.yaml#L30
The workflow is not valid. .github/workflows/pipeline.yaml (Line: 30, Col: 3): Error calling workflow 'Einsteiniumeinsteinian/Kantox-main-api/.github/workflows/re_tag_current_image.yaml@25f4c6031ba25d16e570745f8249930caf497be5'. The nested job 're_tag_current_latest' is requesting 'id-token: write', but is only allowed 'id-token: none'.`